### PR TITLE
Add workflows to automate project management

### DIFF
--- a/.github/workflows/add-to-kanban-project.yml
+++ b/.github/workflows/add-to-kanban-project.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/Okura-JCH/projects/2
+          project-url: https://github.com/orgs/NID-roid/projects/1
           github-token: ${{ secrets.PROJECT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/add-to-kanban-project.yml
+++ b/.github/workflows/add-to-kanban-project.yml
@@ -1,0 +1,19 @@
+name: Add to Kanban Project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/Okura-JCH/projects/2
+          github-token: ${{ secrets.PROJECT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/assign-pr-creator.yml
+++ b/.github/workflows/assign-pr-creator.yml
@@ -1,0 +1,25 @@
+name: Assign PR Creator
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Assign PR Creator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const actor = process.env.GITHUB_ACTOR;
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [actor]
+            });
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds two workflows to automate project management tasks. The "Add to Kanban Project" workflow adds newly opened issues and pull requests to a specific project board. The "Assign PR Creator" workflow automatically assigns the creator of a pull request to the PR. These workflows aim to streamline project management processes and improve efficiency.

Close #9